### PR TITLE
Fix label width alignment across sections

### DIFF
--- a/parameter_tab.py
+++ b/parameter_tab.py
@@ -68,6 +68,12 @@ class ParameterTab(ttk.Frame):
                     key, value = map(str.strip, line.split("=", 1))
                     self.sections.setdefault(current_section, OrderedDict())[key] = value
 
+        # determine the widest parameter name for consistent label width
+        self.max_label_len = max(
+            (len(key) for params in self.sections.values() for key in params),
+            default=0,
+        )
+
     def refresh_ui(self):
         for widget in self.scrollable_content.winfo_children():
             widget.destroy()
@@ -88,9 +94,13 @@ class ParameterTab(ttk.Frame):
         parameter_frame = ttk.Frame(section_info["frame"], borderwidth=1, relief="solid")
         parameter_frame.grid(row=row, column=column, padx=4, pady=4, sticky="nsew")
 
-        ttk.Label(parameter_frame, text=param_name, font=("Arial", 8, "bold")).grid(
-            row=0, column=0, columnspan=2, sticky=tk.W
-        )
+        ttk.Label(
+            parameter_frame,
+            text=param_name,
+            font=("Arial", 8, "bold"),
+            width=max(self.max_label_len, 1),
+            anchor=tk.W,
+        ).grid(row=0, column=0, columnspan=2, sticky=tk.W)
 
         toggle_button = tk.Button(
             parameter_frame,


### PR DESCRIPTION
## Summary
- compute the longest parameter label when reading an INI file
- use the longest length to set a uniform width for parameter labels

## Testing
- `python -m py_compile parameter_tab.py parameter_manager.py INI_EDIT.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b72eb11c083318e3cf0860f5006f1