### PR TITLE
Fix uniform grid layout for parameter sections

### DIFF
--- a/parameter_tab.py
+++ b/parameter_tab.py
@@ -188,7 +188,7 @@ class ParameterTab(ttk.Frame):
         for section, info in self.widget_registry.items():
             section_frame = info["frame"]
             for i in range(self.grid_columns):
-                section_frame.columnconfigure(i, weight=1)
+                section_frame.columnconfigure(i, weight=1, uniform="param_cols")
             for index, param_name in enumerate(self.sections[section].keys()):
                 frame = info["params"][param_name][0]
                 row, column = divmod(index, self.grid_columns)


### PR DESCRIPTION
## Summary
- keep grid column widths consistent across sections

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684b782728488331af840fc8e7c451a4