### PR TITLE
Fix memory cleanup for closed tabs

### DIFF
--- a/parameter_manager.py
+++ b/parameter_manager.py
@@ -87,11 +87,15 @@ class ParameterManagerGUI:
         for path, t in list(self.tabs.items()):
             if t == tab:
                 file_path = path
-                del self.tabs[path]
                 break
+
         self.notebook.forget(index)
-        if file_path in self.open_files:
-            self.open_files.remove(file_path)
+        tab.destroy()
+
+        if file_path:
+            self.tabs.pop(file_path, None)
+            if file_path in self.open_files:
+                self.open_files.remove(file_path)
 
     def on_close(self):
         self.save_state()


### PR DESCRIPTION
## Summary
- ensure `ParameterManagerGUI.close_current_tab` properly destroys tabs
- drop lingering tab references before removing from the notebook

## Testing
- `python -m py_compile parameter_manager.py parameter_tab.py INI_EDIT.py`

------
https://chatgpt.com/codex/tasks/task_e_684b8735295c8331a5d6a4b29528ff52