### PR TITLE
Add per-file UI state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ python INI_EDIT.py
 ```
 
 Any INI files opened will be listed in a tabbed interface. When closing the
-program, the set of open files and window size are stored in `gui/state.json`
-and reloaded on the next start.
+program, the set of open files, window size and per-file UI state (collapsed
+sections and custom ordering) are stored in `gui/state.json` and reloaded on the
+next start so the interface appears exactly as you left it.
 
 ## Contributing
 - Follow [PEP 8](https://peps.python.org/pep-0008/) for code style.

--- a/gui/parameter_manager.py
+++ b/gui/parameter_manager.py
@@ -10,7 +10,8 @@ class ParameterManagerGUI:
         self.state_path = os.path.join(os.path.dirname(__file__), "state.json")
         self.open_files = []
         self.saved_geometry = None
-        self.saved_geometry, self.open_files = load_state(self.state_path)
+        self.file_states = {}
+        self.saved_geometry, self.open_files, self.file_states = load_state(self.state_path)
 
         self.notebook = ttk.Notebook(self.root_window)
         self.notebook.pack(fill=tk.BOTH, expand=True)
@@ -77,11 +78,19 @@ class ParameterManagerGUI:
                 self.open_files.remove(file_path)
 
     def on_close(self):
-        save_state(self.state_path, self.root_window.geometry(), list(self.tabs.keys()))
+        for path, tab in self.tabs.items():
+            self.file_states[path] = tab.get_state()
+        save_state(
+            self.state_path,
+            self.root_window.geometry(),
+            list(self.tabs.keys()),
+            self.file_states,
+        )
         self.root_window.destroy()
 
     def _open_file(self, file_path):
-        tab = ParameterTab(self.notebook, file_path)
+        tab_state = self.file_states.get(file_path)
+        tab = ParameterTab(self.notebook, file_path, initial_state=tab_state)
         self.notebook.add(tab, text=os.path.basename(file_path))
         self.tabs[file_path] = tab
         tab.adjust_window_size()

--- a/state_manager.py
+++ b/state_manager.py
@@ -3,23 +3,30 @@ import os
 
 
 def load_state(state_path):
-    """Load GUI state from JSON file."""
+    """Load GUI state from JSON file.
+
+    Returns a tuple ``(geometry, files, file_states)`` where ``file_states``
+    holds any per-file UI information saved by the GUI. ``file_states`` will be
+    an empty dictionary if no state file exists or it does not contain that key.
+    """
     saved_geometry = None
     open_files = []
+    file_states = {}
     if os.path.exists(state_path):
         try:
             with open(state_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
                 saved_geometry = data.get("geometry")
                 open_files = data.get("files", [])
+                file_states = data.get("file_states", {})
         except Exception:
             pass
-    return saved_geometry, open_files
+    return saved_geometry, open_files, file_states
 
 
-def save_state(state_path, geometry, files):
+def save_state(state_path, geometry, files, file_states):
     """Save GUI state to JSON file."""
-    state = {"geometry": geometry, "files": files}
+    state = {"geometry": geometry, "files": files, "file_states": file_states}
     try:
         with open(state_path, "w", encoding="utf-8") as f:
             json.dump(state, f)


### PR DESCRIPTION
## Summary
- extend `state_manager` to keep UI state for each opened file
- preserve section order and collapsed state in `ParameterTab`
- restore and save these states from `ParameterManagerGUI`
- document new persistence behavior in `README`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b8d20e0e88331b57424c62ea1f256