### PR TITLE
Implement snapping resize width

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ program, the set of open files, window size and per-file UI state (collapsed
 sections and custom ordering) are stored in `gui/state.json` and reloaded on the
 next start so the interface appears exactly as you left it.
 
+When resizing the main window, its width now snaps to the nearest 120 pixel
+increment to keep parameter columns aligned.
+
 ## Contributing
 - Follow [PEP 8](https://peps.python.org/pep-0008/) for code style.
 - Submit pull requests with clear descriptions of changes.

--- a/gui/parameter_tab.py
+++ b/gui/parameter_tab.py
@@ -200,6 +200,13 @@ class ParameterTab(ttk.Frame):
 
     def on_resize(self, event):
         new_cols = max(1, event.width // 120)
+        toplevel = self.winfo_toplevel()
+        padding = toplevel.winfo_width() - self.winfo_width()
+        snap_width = new_cols * 120 + padding
+
+        if toplevel.winfo_width() != snap_width:
+            toplevel.geometry(f"{snap_width}x{toplevel.winfo_height()}")
+
         if new_cols != self.grid_columns:
             self.grid_columns = new_cols
             self.layout_parameters()


### PR DESCRIPTION
## Summary
- update README with snapping behavior note
- implement snapped width geometry in ParameterTab.on_resize

## Testing
- `python -m py_compile INI_EDIT.py config_io.py state_manager.py gui/__init__.py gui/parameter_manager.py gui/parameter_tab.py`

------
https://chatgpt.com/codex/tasks/task_e_684b93736450833193d3517a0f366cf0