### PR TITLE
Fix indentation and duplicate code in on_resize

### DIFF
--- a/gui/parameter_tab.py
+++ b/gui/parameter_tab.py
@@ -233,13 +233,6 @@ class ParameterTab(ttk.Frame):
             self.grid_columns = new_cols
             self.layout_parameters()
             self.adjust_window_size()
- main
-            toplevel.geometry(f"{snap_width}x{toplevel.winfo_height()}")
-
-        if new_cols != self.grid_columns:
-            self.grid_columns = new_cols
-            self.layout_parameters()
-            self.adjust_window_size()
 
     def layout_parameters(self):
         for section, info in self.widget_registry.items():


### PR DESCRIPTION
## Summary
- deduplicate geometry updates in `on_resize`
- fix stray text and ensure resize handler ends cleanly

## Testing
- `python -m py_compile gui/parameter_tab.py`


------
https://chatgpt.com/codex/tasks/task_e_684b9e731e008331ab78033a2198de04