### PR TITLE
Implement snapped resize only on user action

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ program, the set of open files, window size and per-file UI state (collapsed
 sections and custom ordering) are stored in `gui/state.json` and reloaded on the
 next start so the interface appears exactly as you left it.
 
+When you manually resize the main window, its width snaps to the nearest
+120‑pixel increment to keep parameter columns aligned.
+
 ## Contributing
 - Follow [PEP 8](https://peps.python.org/pep-0008/) for code style.
 - Submit pull requests with clear descriptions of changes.

--- a/gui/parameter_tab.py
+++ b/gui/parameter_tab.py
@@ -37,7 +37,10 @@ class ParameterTab(ttk.Frame):
         self.bind_all("<Button-5>", self._on_mousewheel)
 
         # track size changes to recompute layout
-        self.bind("<Configure>", self.on_resize)
+        self._snap_initialized = False
+        self._last_snapped_width = None
+        self._padding = 0
+        self.winfo_toplevel().bind("<Configure>", self.on_resize)
 
         self.load_parameters()
 
@@ -199,7 +202,27 @@ class ParameterTab(ttk.Frame):
             self.canvas.yview_scroll(1, "units")
 
     def on_resize(self, event):
-        new_cols = max(1, event.width // 120)
+        toplevel = self.winfo_toplevel()
+
+        if event.widget is not toplevel:
+            return
+
+        if not self._snap_initialized:
+            self._snap_initialized = True
+            self._padding = event.width - self.winfo_width()
+            return
+
+        if self._last_snapped_width == event.width:
+            self._last_snapped_width = None
+            return
+
+        new_cols = max(1, (event.width - self._padding) // 120)
+        snap_width = new_cols * 120 + self._padding
+
+        if snap_width != event.width:
+            self._last_snapped_width = snap_width
+            toplevel.geometry(f"{snap_width}x{toplevel.winfo_height()}")
+
         if new_cols != self.grid_columns:
             self.grid_columns = new_cols
             self.layout_parameters()


### PR DESCRIPTION
## Summary
- refine snapping note in README
- snap width only when user resizes the toplevel window

## Testing
- `python -m py_compile INI_EDIT.py config_io.py state_manager.py gui/__init__.py gui/parameter_manager.py gui/parameter_tab.py`


------
https://chatgpt.com/codex/tasks/task_e_684b93736450833193d3517a0f366cf0