### PR TITLE
Translate docs to Korean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,31 @@
 # MAIN
 
-This project provides a Tkinter-based GUI for editing INI configuration files.
-It allows multiple INI files to be opened in separate tabs and tracks the window
-state between sessions.
+이 프로젝트는 INI 구성 파일을 편집하기 위한 Tkinter 기반 GUI를 제공합니다.
+여러 INI 파일을 개별 탭에서 열 수 있으며 창 상태를 세션 간 유지합니다.
 
 ## Requirements
-- Python 3.8 or higher
-- Tkinter (bundled with the standard Python distribution)
+- Python 3.8 이상
+- Tkinter(표준 Python 배포판에 포함)
 
-No additional third‑party packages are required.
+추가 서드파티 패키지는 필요하지 않습니다.
 
 ## Project Structure
-- `gui/parameter_tab.py` – dynamic section/parameter UI with toggle buttons
-  and editable fields.
-- `gui/parameter_manager.py` – manages tabs for multiple files and persists
-  window geometry and open files to `state.json` using `state_manager.py`.
-- `state_manager.py` – load/save helpers for the JSON state file.
-- `config_io.py` – utilities for reading and writing INI-style files.
-- `INI_EDIT.py` – entry point that launches the GUI.
+- `gui/parameter_tab.py` – 토글 버튼과 편집 가능한 필드를 갖춘 동적 섹션/파라미터 UI
+- `gui/parameter_manager.py` – 여러 파일을 위한 탭을 관리하고 `state_manager.py`를 사용해 창 크기와 열려 있는 파일 정보를 `state.json`에 저장
+- `state_manager.py` – JSON 상태 파일을 로드하고 저장하는 헬퍼
+- `config_io.py` – INI 형식 파일을 읽고 쓰기 위한 유틸리티
+- `INI_EDIT.py` – GUI를 실행하는 시작 지점
 
 ## Usage
-Run the application from the repository root:
+저장소 루트에서 다음과 같이 실행합니다:
 
 ```bash
 python INI_EDIT.py
 ```
 
-Any INI files opened will be listed in a tabbed interface. When closing the
-program, the set of open files, window size and per-file UI state (collapsed
-sections and custom ordering) are stored in `gui/state.json` and reloaded on the
-next start so the interface appears exactly as you left it.
+열린 INI 파일들은 탭 인터페이스에 표시됩니다. 프로그램을 종료하면 열린 파일 목록, 창 크기, 파일별 UI 상태(접힘 상태와 사용자 지정 순서)가 `gui/state.json`에 저장되며 다음 실행 시 그대로 복원됩니다.
 
 ## Contributing
-- Follow [PEP 8](https://peps.python.org/pep-0008/) for code style.
-- Submit pull requests with clear descriptions of changes.
-- If adding new modules or features, include docstrings and update this README
-  accordingly.
+- 코드 스타일은 [PEP 8](https://peps.python.org/pep-0008/)을 따르세요.
+- 변경 사항에 대한 명확한 설명과 함께 풀 리퀘스트를 제출하세요.
+- 새로운 모듈이나 기능을 추가할 경우 docstring을 작성하고 이 README도 갱신하세요.

--- a/config_io.py
+++ b/config_io.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 
 def compute_file_hash(filepath):
-    """Return md5 hash of file content or None if file does not exist."""
+    """파일이 존재하면 내용의 md5 해시를, 없으면 ``None`` 을 반환한다."""
     if not filepath:
         return None
     try:
@@ -14,7 +14,7 @@ def compute_file_hash(filepath):
 
 
 def load_parameters(filepath):
-    """Load parameters from INI-like file into an OrderedDict sections structure."""
+    """INI 형식 파일에서 파라미터를 읽어 OrderedDict 섹션 구조로 반환한다."""
     sections = OrderedDict()
     if not filepath:
         return sections
@@ -35,7 +35,7 @@ def load_parameters(filepath):
 
 
 def save_parameters(filepath, sections):
-    """Save parameters sections structure back to an INI-like file."""
+    """파라미터 섹션 구조를 INI 형식 파일에 저장한다."""
     if not filepath:
         return
     with open(filepath, "w", encoding="utf-8") as file:

--- a/gui/parameter_tab.py
+++ b/gui/parameter_tab.py
@@ -13,7 +13,7 @@ class ParameterTab(ttk.Frame):
         self.widget_registry = {}
         self.section_states = (initial_state or {}).get("collapsed", {})
         self._saved_order = (initial_state or {}).get("order")
-        # initial column count; will adjust on resize
+        # 초기 열 수; 창 크기에 따라 조정됨
         self.grid_columns = 4
 
         self.canvas = tk.Canvas(self)
@@ -31,12 +31,12 @@ class ParameterTab(ttk.Frame):
         self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
 
-        # enable mouse wheel scrolling anywhere inside the tab
+        # 탭 내부 어디서나 마우스 휠 스크롤을 가능하게 함
         self.bind_all("<MouseWheel>", self._on_mousewheel)
         self.bind_all("<Button-4>", self._on_mousewheel)
         self.bind_all("<Button-5>", self._on_mousewheel)
 
-        # track size changes to recompute layout
+        # 크기 변화를 감지하여 레이아웃을 다시 계산
         self.bind("<Configure>", self.on_resize)
 
         self.load_parameters()
@@ -250,7 +250,7 @@ class ParameterTab(ttk.Frame):
             save_parameters(self.file_path, self.sections)
 
     def get_state(self):
-        """Return collapsed state and section order for persistence."""
+        """접힌 상태와 섹션 순서를 반환하여 저장에 사용한다."""
         return {
             "collapsed": self.section_states,
             "order": list(self.sections.keys()),

--- a/state_manager.py
+++ b/state_manager.py
@@ -3,11 +3,11 @@ import os
 
 
 def load_state(state_path):
-    """Load GUI state from JSON file.
+    """JSON 파일에서 GUI 상태를 로드한다.
 
-    Returns a tuple ``(geometry, files, file_states)`` where ``file_states``
-    holds any per-file UI information saved by the GUI. ``file_states`` will be
-    an empty dictionary if no state file exists or it does not contain that key.
+    반환 값은 ``(geometry, files, file_states)`` 튜플이며, ``file_states``는
+    GUI가 저장한 파일별 UI 정보를 담는다. 상태 파일이 없거나 해당 키가
+    없으면 ``file_states`` 는 빈 딕셔너리가 된다.
     """
     saved_geometry = None
     open_files = []
@@ -25,7 +25,7 @@ def load_state(state_path):
 
 
 def save_state(state_path, geometry, files, file_states):
-    """Save GUI state to JSON file."""
+    """GUI 상태를 JSON 파일로 저장한다."""
     state = {"geometry": geometry, "files": files, "file_states": file_states}
     try:
         with open(state_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- translate README to Korean
- update docstrings in `config_io.py` and `state_manager.py`
- translate comments and docstrings in `gui/parameter_tab.py`

## Testing
- `python -m py_compile *.py gui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684b932894d08331b8ab16d193d9dc37