### PR TITLE
README와 주석 한글화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,32 @@
 # MAIN
 
-This project provides a Tkinter-based GUI for editing INI configuration files.
-It allows multiple INI files to be opened in separate tabs and tracks the window
-state between sessions.
+이 프로젝트는 INI 구성 파일을 편집하기 위한 Tkinter 기반 GUI를 제공합니다. 여러 INI 파일을 각각 탭으로 열 수 있으며 프로그램을 종료해도 창 크기와 열린 파일 목록이 저장되어 다음 실행 시 복원됩니다.
 
-## Requirements
-- Python 3.8 or higher
-- Tkinter (bundled with the standard Python distribution)
+## 요구 사항
+- Python 3.8 이상
+- Tkinter (표준 Python 배포판에 포함)
 
-No additional third‑party packages are required.
+추가 서드파티 패키지 설치는 필요하지 않습니다.
 
-## Project Structure
-- `gui/parameter_tab.py` – dynamic section/parameter UI with toggle buttons
-  and editable fields.
-- `gui/parameter_manager.py` – manages tabs for multiple files and persists
-  window geometry and open files to `state.json` using `state_manager.py`.
-- `state_manager.py` – load/save helpers for the JSON state file.
-- `config_io.py` – utilities for reading and writing INI-style files.
-- `INI_EDIT.py` – entry point that launches the GUI.
+## 프로젝트 구조
+- `gui/parameter_tab.py` – 토글 버튼과 편집 필드를 갖춘 동적 섹션/파라미터 UI
+- `gui/parameter_manager.py` – 여러 파일 탭을 관리하고 `state_manager.py`를 사용해 창 상태를 `state.json`에 저장
+- `state_manager.py` – JSON 상태 파일을 불러오고 저장하는 헬퍼
+- `config_io.py` – INI 형식 파일을 읽고 쓰는 유틸리티
+- `INI_EDIT.py` – GUI를 실행하는 진입점
 
-## Usage
-Run the application from the repository root:
+## 사용법
+레포지토리 루트에서 다음 명령으로 실행합니다.
 
 ```bash
 python INI_EDIT.py
 ```
 
-Any INI files opened will be listed in a tabbed interface. When closing the
-program, the set of open files, window size and per-file UI state (collapsed
-sections and custom ordering) are stored in `gui/state.json` and reloaded on the
-next start so the interface appears exactly as you left it.
+열린 INI 파일들은 탭 인터페이스에 표시됩니다. 창을 닫을 때 열린 파일 목록, 창 크기, 섹션 접힘 상태 등이 `gui/state.json`에 기록되며 다음 실행 시 그대로 복원됩니다.
 
-n30yli-codex/modify-window-resizing-to-snap-to-columns
-When you manually resize the main window, its width snaps to the nearest
-120‑pixel increment to keep parameter columns aligned.
- main
+메인 창 크기를 수동으로 조절하면 폭이 120픽셀 단위로 스냅되어 파라미터 컬럼 정렬을 유지합니다.
 
-## Contributing
-- Follow [PEP 8](https://peps.python.org/pep-0008/) for code style.
-- Submit pull requests with clear descriptions of changes.
-- If adding new modules or features, include docstrings and update this README
-  accordingly.
+## 기여 방법
+- 코드 스타일은 [PEP 8](https://peps.python.org/pep-0008/)을 따릅니다.
+- 변경 사항을 명확히 설명한 풀 리퀘스트를 보내 주세요.
+- 새 모듈이나 기능을 추가할 경우 주석 및 이 README를 함께 업데이트해 주세요.

--- a/config_io.py
+++ b/config_io.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 
 def compute_file_hash(filepath):
-    """Return md5 hash of file content or None if file does not exist."""
+    """파일이 존재하면 md5 해시를 반환하고 없으면 ``None``을 반환합니다."""
     if not filepath:
         return None
     try:
@@ -14,7 +14,7 @@ def compute_file_hash(filepath):
 
 
 def load_parameters(filepath):
-    """Load parameters from INI-like file into an OrderedDict sections structure."""
+    """INI 형식 파일을 읽어 ``OrderedDict`` 구조로 파라미터를 불러옵니다."""
     sections = OrderedDict()
     if not filepath:
         return sections
@@ -35,7 +35,7 @@ def load_parameters(filepath):
 
 
 def save_parameters(filepath, sections):
-    """Save parameters sections structure back to an INI-like file."""
+    """파라미터 섹션 구조를 INI 형식 파일로 저장합니다."""
     if not filepath:
         return
     with open(filepath, "w", encoding="utf-8") as file:

--- a/gui/parameter_tab.py
+++ b/gui/parameter_tab.py
@@ -13,7 +13,7 @@ class ParameterTab(ttk.Frame):
         self.widget_registry = {}
         self.section_states = (initial_state or {}).get("collapsed", {})
         self._saved_order = (initial_state or {}).get("order")
-        # initial column count; will adjust on resize
+        # 초기 열 개수, 창 크기에 맞춰 조정됩니다
         self.grid_columns = 4
 
         self.canvas = tk.Canvas(self)
@@ -31,12 +31,12 @@ class ParameterTab(ttk.Frame):
         self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
 
-        # enable mouse wheel scrolling anywhere inside the tab
+        # 탭 내부 어디서나 마우스 휠 스크롤을 허용
         self.bind_all("<MouseWheel>", self._on_mousewheel)
         self.bind_all("<Button-4>", self._on_mousewheel)
         self.bind_all("<Button-5>", self._on_mousewheel)
 
-        # track size changes to recompute layout
+        # 창 크기 변화를 감지해 레이아웃을 재계산
         self._snap_initialized = False
         self._last_snapped_width = None
         self._padding = 0
@@ -63,8 +63,6 @@ class ParameterTab(ttk.Frame):
         self.refresh_ui()
         self.adjust_window_size()
         self.after(100, self.monitor_file_changes)
-
- main
 
     def refresh_ui(self):
         for widget in self.scrollable_content.winfo_children():
@@ -203,7 +201,6 @@ class ParameterTab(ttk.Frame):
         elif event.num == 5:
             self.canvas.yview_scroll(1, "units")
 
- n30yli-codex/modify-window-resizing-to-snap-to-columns
     def on_resize(self, event):
         toplevel = self.winfo_toplevel()
 
@@ -230,7 +227,6 @@ class ParameterTab(ttk.Frame):
             self.grid_columns = new_cols
             self.layout_parameters()
             self.adjust_window_size()
- main
 
         # 2) 최초 이벤트는 스냅 초기화만 수행
         if not self._snap_initialized:
@@ -305,7 +301,7 @@ class ParameterTab(ttk.Frame):
             save_parameters(self.file_path, self.sections)
 
     def get_state(self):
-        """Return collapsed state and section order for persistence."""
+        """섹션 접힘 상태와 순서를 저장하기 위한 딕셔너리를 반환합니다."""
         return {
             "collapsed": self.section_states,
             "order": list(self.sections.keys()),

--- a/state_manager.py
+++ b/state_manager.py
@@ -3,11 +3,11 @@ import os
 
 
 def load_state(state_path):
-    """Load GUI state from JSON file.
+    """JSON 파일에서 GUI 상태를 읽어옵니다.
 
-    Returns a tuple ``(geometry, files, file_states)`` where ``file_states``
-    holds any per-file UI information saved by the GUI. ``file_states`` will be
-    an empty dictionary if no state file exists or it does not contain that key.
+    반환 값은 ``(geometry, files, file_states)`` 튜플이며,
+    ``file_states``에는 각 파일별 UI 정보가 저장됩니다.
+    상태 파일이 없거나 해당 키가 없으면 ``file_states`` 는 빈 딕셔너리를 돌려줍니다.
     """
     saved_geometry = None
     open_files = []
@@ -25,7 +25,7 @@ def load_state(state_path):
 
 
 def save_state(state_path, geometry, files, file_states):
-    """Save GUI state to JSON file."""
+    """GUI 상태를 JSON 파일로 저장합니다."""
     state = {"geometry": geometry, "files": files, "file_states": file_states}
     try:
         with open(state_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- 한국어 README 작성
- 코드 주석과 Docstring을 한국어로 번역
- 불필요하게 남아 있던 문자열 제거 및 정리

## Testing
- `python -m py_compile INI_EDIT.py config_io.py state_manager.py gui/parameter_manager.py gui/parameter_tab.py`

------
https://chatgpt.com/codex/tasks/task_e_684ba95bc5fc833181bf71e04188aaa5