### PR TITLE
Add initial pytest suite

### DIFF
--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,0 +1,36 @@
+import hashlib
+from collections import OrderedDict
+
+from config_io import compute_file_hash, load_parameters, save_parameters
+
+
+def test_compute_file_hash(tmp_path):
+    ini = tmp_path / "sample.ini"
+    ini.write_text("key=1\n")
+    expected = hashlib.md5(ini.read_bytes()).hexdigest()
+    assert compute_file_hash(str(ini)) == expected
+
+
+def test_compute_file_hash_missing():
+    assert compute_file_hash(None) is None
+    assert compute_file_hash("nonexistent.ini") is None
+
+
+def test_load_parameters(tmp_path):
+    ini = tmp_path / "sample.ini"
+    ini.write_text("key=1\n[Section]\nvalue=2\n# comment\n; semi\n")
+    sections = load_parameters(str(ini))
+    assert list(sections.keys()) == ["DEFAULT", "Section"]
+    assert sections["DEFAULT"]["key"] == "1"
+    assert sections["Section"]["value"] == "2"
+
+
+def test_save_parameters_roundtrip(tmp_path):
+    sections = OrderedDict([
+        ("DEFAULT", OrderedDict([("key", "1")])),
+        ("Section", OrderedDict([("value", "2")]))
+    ])
+    output = tmp_path / "out.ini"
+    save_parameters(str(output), sections)
+    reloaded = load_parameters(str(output))
+    assert reloaded == sections

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,18 @@
+from state_manager import load_state, save_state
+
+
+def test_load_state_missing(tmp_path):
+    missing = tmp_path / "state.json"
+    assert load_state(str(missing)) == (None, [], {})
+
+
+def test_save_and_load_state(tmp_path):
+    state_file = tmp_path / "state.json"
+    geometry = "800x600+100+100"
+    files = ["a.ini", "b.ini"]
+    file_states = {"a.ini": {"collapsed": {"Sec": True}}}
+    save_state(str(state_file), geometry, files, file_states)
+    loaded_geometry, loaded_files, loaded_states = load_state(str(state_file))
+    assert loaded_geometry == geometry
+    assert loaded_files == files
+    assert loaded_states == file_states


### PR DESCRIPTION
## Summary
- set up `tests/` package for pytest discovery
- cover `config_io` and `state_manager` utility functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bbd09e11483318bb8b2c20bb48b85