### PR TITLE
Fix layout refresh when switching tabs

### DIFF
--- a/gui/parameter_manager.py
+++ b/gui/parameter_manager.py
@@ -16,6 +16,7 @@ class ParameterManagerGUI:
         self.notebook = ttk.Notebook(self.root_window)
         self.notebook.pack(fill=tk.BOTH, expand=True)
         self.notebook.bind("<Button-3>", self.show_tab_menu)
+        self.notebook.bind("<<NotebookTabChanged>>", self.on_tab_changed)
 
         self.tab_menu = tk.Menu(self.notebook, tearoff=0)
         self.tab_menu.add_command(label="Close", command=self.close_current_tab)
@@ -93,7 +94,14 @@ class ParameterManagerGUI:
         tab = ParameterTab(self.notebook, file_path, initial_state=tab_state)
         self.notebook.add(tab, text=os.path.basename(file_path))
         self.tabs[file_path] = tab
-        tab.adjust_window_size()
+        self.notebook.select(tab)
+        tab.update_layout_for_current_size()
         if file_path not in self.open_files:
             self.open_files.append(file_path)
+
+    def on_tab_changed(self, event):
+        tab_id = self.notebook.select()
+        tab = self.notebook.nametowidget(tab_id)
+        if hasattr(tab, "update_layout_for_current_size"):
+            tab.update_layout_for_current_size()
 

--- a/gui/parameter_tab.py
+++ b/gui/parameter_tab.py
@@ -52,6 +52,22 @@ class ParameterTab(ttk.Frame):
 
         self.load_parameters()
 
+    def update_layout_for_current_size(self):
+        """Recalculate grid layout using the current toplevel size."""
+        if not self.winfo_exists():
+            return
+        toplevel = self.winfo_toplevel()
+        self.update_idletasks()
+        self._padding = toplevel.winfo_width() - self.winfo_width()
+        self._padding_initialized = True
+        width = toplevel.winfo_width()
+        new_cols = max(1, (width - self._padding) // self.cell_width)
+        self.canvas.itemconfigure(self.canvas_window, width=width - self._padding)
+        if new_cols != self.grid_columns:
+            self.grid_columns = new_cols
+            self.layout_parameters()
+        self.adjust_window_size()
+
     def load_parameters(self):
         self.last_file_hash = compute_file_hash(self.file_path)
         self.sections = load_parameters(self.file_path)


### PR DESCRIPTION
## Summary
- recalc layout whenever tab is activated
- update layout on initial open
- provide helper to recompute layout for current window size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bbffe1c948331885e1cddab6c4846