### PR TITLE
Persist state in user home

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## 프로젝트 구조
 - `gui/parameter_tab.py` – 토글 버튼과 편집 필드를 갖춘 동적 섹션/파라미터 UI
-- `gui/parameter_manager.py` – 여러 파일 탭을 관리하고 `state_manager.py`를 사용해 창 상태를 `state.json`에 저장
+- `gui/parameter_manager.py` – 여러 파일 탭을 관리하고 `state_manager.py`를 사용해 창 상태를 사용자의 홈 디렉터리 아래 `.ini_editor/state.json`에 저장
 - `state_manager.py` – JSON 상태 파일을 불러오고 저장하는 헬퍼
 - `config_io.py` – INI 형식 파일을 읽고 쓰는 유틸리티
 - `INI_EDIT.py` – GUI를 실행하는 진입점
@@ -22,7 +22,7 @@
 python INI_EDIT.py
 ```
 
-열린 INI 파일들은 탭 인터페이스에 표시됩니다. 창을 닫을 때 열린 파일 목록, 창 크기, 섹션 접힘 상태 등이 `gui/state.json`에 기록되며 다음 실행 시 그대로 복원됩니다.
+열린 INI 파일들은 탭 인터페이스에 표시됩니다. 창을 닫을 때 열린 파일 목록, 창 크기, 섹션 접힘 상태 등이 사용자의 홈 디렉터리 아래 `.ini_editor/state.json`에 기록되며 다음 실행 시 그대로 복원됩니다. 읽기나 쓰기에 실패하면 경고 로그가 남습니다.
 
 메인 창 크기를 자유롭게 조절하면 즉시 적용되며 스냅 제한은 없습니다.
 

--- a/gui/parameter_manager.py
+++ b/gui/parameter_manager.py
@@ -7,7 +7,9 @@ from state_manager import load_state, save_state
 class ParameterManagerGUI:
     def __init__(self, root_window):
         self.root_window = root_window
-        self.state_path = os.path.join(os.path.dirname(__file__), "state.json")
+        # store window state in a user writable location
+        self.state_path = os.path.expanduser("~/.ini_editor/state.json")
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
         self.open_files = []
         self.saved_geometry = None
         self.file_states = {}

--- a/state_manager.py
+++ b/state_manager.py
@@ -1,5 +1,8 @@
 import json
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def load_state(state_path):
@@ -19,8 +22,10 @@ def load_state(state_path):
                 saved_geometry = data.get("geometry")
                 open_files = data.get("files", [])
                 file_states = data.get("file_states", {})
-        except Exception:
-            pass
+        except json.JSONDecodeError as e:
+            logger.warning("Failed to parse state file %s: %s", state_path, e)
+        except OSError as e:
+            logger.warning("Failed to read state file %s: %s", state_path, e)
     return saved_geometry, open_files, file_states
 
 
@@ -28,7 +33,8 @@ def save_state(state_path, geometry, files, file_states):
     """GUI 상태를 JSON 파일로 저장합니다."""
     state = {"geometry": geometry, "files": files, "file_states": file_states}
     try:
+        os.makedirs(os.path.dirname(state_path), exist_ok=True)
         with open(state_path, "w", encoding="utf-8") as f:
             json.dump(state, f)
-    except Exception:
-        pass
+    except OSError as e:
+        logger.warning("Failed to write state file %s: %s", state_path, e)


### PR DESCRIPTION
## Summary
- save window state under `~/.ini_editor/state.json`
- warn when state file read/write fails
- document new location and logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc5a77b488331b67a16dd357d9c64