### PR TITLE
Improve resize handling in GUI

### DIFF
--- a/gui/parameter_manager.py
+++ b/gui/parameter_manager.py
@@ -33,6 +33,8 @@ class ParameterManagerGUI:
             if os.path.exists(f):
                 self._open_file(f)
         self.root_window.protocol("WM_DELETE_WINDOW", self.on_close)
+        # Bind once to handle window resize events and delegate to the active tab
+        self._resize_bind_id = self.root_window.bind("<Configure>", self.on_root_resize)
 
     def switch_active_tab(self, new_tab):
         """Manage global mouse wheel bindings when the active tab changes."""
@@ -103,6 +105,9 @@ class ParameterManagerGUI:
             self.file_states,
         )
         self.switch_active_tab(None)
+        # remove resize binding before destroying the window
+        if hasattr(self, "_resize_bind_id"):
+            self.root_window.unbind("<Configure>", self._resize_bind_id)
         self.root_window.destroy()
 
     def _open_file(self, file_path):
@@ -122,4 +127,9 @@ class ParameterManagerGUI:
         self.switch_active_tab(tab)
         if hasattr(tab, "update_layout_for_current_size"):
             tab.update_layout_for_current_size()
+
+    def on_root_resize(self, event):
+        """Delegate root <Configure> events to the active tab."""
+        if self.current_tab and hasattr(self.current_tab, "on_resize"):
+            self.current_tab.on_resize(event)
 

--- a/gui/parameter_tab.py
+++ b/gui/parameter_tab.py
@@ -45,11 +45,11 @@ class ParameterTab(ttk.Frame):
         # 각 탭이 활성화될 때 bind_mousewheel()을 호출해 전역 스크롤을 설정한다.
 
         # 창 크기 변화를 감지해 레이아웃을 재계산
+        # ParameterManagerGUI will delegate resize events to the active tab,
+        # so no direct binding is done here.
         self._padding = 0
         self._padding_initialized = False
-        self._resize_bind_id = self.winfo_toplevel().bind(
-            "<Configure>", self.on_resize, add="+"
-        )
+        self._resize_bind_id = None
 
         self.load_parameters()
 
@@ -344,9 +344,8 @@ class ParameterTab(ttk.Frame):
 
     def destroy(self):
         """Remove event bindings and destroy the tab."""
-        toplevel = self.winfo_toplevel()
-        if hasattr(self, "_resize_bind_id"):
-            toplevel.unbind("<Configure>", self._resize_bind_id)
+        # Resize events are managed by ParameterManagerGUI, so no unbinding
+        # of <Configure> is necessary here.
         self.unbind_mousewheel()
         super().destroy()
 


### PR DESCRIPTION
## Summary
- delegate resize events through `ParameterManagerGUI`
- drop per-tab `<Configure>` bindings
- cleanup tab destroy logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5974a1d08331a0ef63f6dfb699bc