### PR TITLE
Implement dynamic cell size control

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ python INI_EDIT.py
 열린 INI 파일들은 탭 인터페이스에 표시됩니다. 창을 닫을 때 열린 파일 목록, 창 크기, 섹션 접힘 상태 등이 사용자의 홈 디렉터리 아래 `.ini_editor/state.json`에 기록되며 다음 실행 시 그대로 복원됩니다. 읽기나 쓰기에 실패하면 경고 로그가 남습니다.
 
 메인 창 크기를 자유롭게 조절하면 즉시 적용되며 스냅 제한은 없습니다.
+셀 크기를 조절하려면 메뉴 바의 "View" 메뉴에서 "Increase Cell Size" 또는 "Decrease Cell Size"를 선택하세요.
 
 ## 기여 방법
 - 코드 스타일은 [PEP 8](https://peps.python.org/pep-0008/)을 따릅니다.

--- a/gui/parameter_manager.py
+++ b/gui/parameter_manager.py
@@ -52,6 +52,11 @@ class ParameterManagerGUI:
         file_menu.add_command(label="Open File(s)", command=self.open_files_dialog)
         file_menu.add_command(label="Exit", command=self.on_close)
         menu_bar.add_cascade(label="File", menu=file_menu)
+
+        view_menu = tk.Menu(menu_bar, tearoff=0)
+        view_menu.add_command(label="Increase Cell Size", command=self.increase_cell_size)
+        view_menu.add_command(label="Decrease Cell Size", command=self.decrease_cell_size)
+        menu_bar.add_cascade(label="View", menu=view_menu)
         self.root_window.config(menu=menu_bar)
 
 
@@ -120,6 +125,14 @@ class ParameterManagerGUI:
         self.switch_active_tab(tab)
         if file_path not in self.open_files:
             self.open_files.append(file_path)
+
+    def increase_cell_size(self):
+        if self.current_tab and hasattr(self.current_tab, "increase_cell_size"):
+            self.current_tab.increase_cell_size()
+
+    def decrease_cell_size(self):
+        if self.current_tab and hasattr(self.current_tab, "decrease_cell_size"):
+            self.current_tab.decrease_cell_size()
 
     def on_tab_changed(self, event):
         tab_id = self.notebook.select()

--- a/tests/test_parameter_tab.py
+++ b/tests/test_parameter_tab.py
@@ -1,0 +1,39 @@
+import types
+from gui.parameter_tab import ParameterTab
+
+class DummyTab(ParameterTab):
+    def __init__(self, width):
+        # don't call super().__init__
+        self.cell_width = width
+        self.widget_registry = {}
+        self.sections = {}
+        self.layout_called = False
+        self.adjust_called = False
+
+    def layout_parameters(self):
+        self.layout_called = True
+
+    def adjust_window_size(self):
+        self.adjust_called = True
+
+
+def test_resize_methods():
+    tab = DummyTab(100)
+    tab.increase_cell_size()
+    assert tab.cell_width == 110
+    assert tab.layout_called
+    assert tab.adjust_called
+
+    tab.layout_called = False
+    tab.adjust_called = False
+    tab.decrease_cell_size()
+    assert tab.cell_width == 100
+    assert tab.layout_called
+    assert tab.adjust_called
+
+    tab.cell_width = 240
+    tab.layout_called = False
+    tab.increase_cell_size()
+    assert tab.cell_width == 240
+    assert tab.layout_called is False
+

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -10,7 +10,7 @@ def test_save_and_load_state(tmp_path):
     state_file = tmp_path / "state.json"
     geometry = "800x600+100+100"
     files = ["a.ini", "b.ini"]
-    file_states = {"a.ini": {"collapsed": {"Sec": True}}}
+    file_states = {"a.ini": {"collapsed": {"Sec": True}, "cell_width": 100}}
     save_state(str(state_file), geometry, files, file_states)
     loaded_geometry, loaded_files, loaded_states = load_state(str(state_file))
     assert loaded_geometry == geometry


### PR DESCRIPTION
## Summary
- add 'Increase Cell Size' and 'Decrease Cell Size' menu under View
- allow ParameterTab to load/save cell_width
- add methods to adjust cell width and update layouts
- handle missing file in monitor_file_changes
- update tests and documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d58d5ca688331bc50c298a079a5ed