### PR TITLE
Fix layout when window is smaller than cell width

### DIFF
--- a/gui/parameter_tab.py
+++ b/gui/parameter_tab.py
@@ -365,7 +365,7 @@ class ParameterTab(ttk.Frame):
         for section, info in self.widget_registry.items():
             container = info["grid_frame"]
             for i in range(self.grid_columns):
-                container.columnconfigure(i, minsize=self.cell_width)
+                container.columnconfigure(i, minsize=0)
             for index, param_name in enumerate(self.sections[section].keys()):
                 frame = info["params"][param_name][0]
                 frame.configure(width=self.cell_width)


### PR DESCRIPTION
## Summary
- allow columns to shrink to fit narrow windows so cells don't overflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d84bf48c8833189db80bf399aa66c